### PR TITLE
Fix reboot in twrp recovery!

### DIFF
--- a/rootdir/init.mt6592.rc
+++ b/rootdir/init.mt6592.rc
@@ -352,6 +352,9 @@ on property:wlan.driver.status=ok
 on property:wlan.driver.status=unloaded
 	write /dev/wmtWifi "0"
 
+on property:sys.powerctl=*
+     powerctl ${sys.powerctl}
+     
 service p2p_supplicant /system/bin/wpa_supplicant -dd \
     -iwlan0 -Dnl80211 -c/data/misc/wifi/wpa_supplicant.conf \
     -I/system/etc/wifi/wpa_supplicant_overlay.conf \


### PR DESCRIPTION
https://gerrit.omnirom.org/#/c/12828/
This breaks reboot for some devices with an old custom init.rc. The fix is to add the following 2 lines to the custom init.rc (or switch from custom init.rc to init.recovery.${ro.hardware}.rc):
   on property:sys.powerctl=*
   powerctl ${sys.powerctl}
