### PR TITLE
Fix missing MTK header to kernel.

### DIFF
--- a/bootimg.mk
+++ b/bootimg.mk
@@ -25,7 +25,8 @@ $(INSTALLED_KERNEL_TARGET).mtk.header: $(INSTALLED_KERNEL_TARGET)
 		$(call make_header, $$((size)), "KERNEL", $@)
 $(INSTALLED_KERNEL_TARGET).mtk: $(INSTALLED_KERNEL_TARGET).mtk.header
 	$(call pretty,"Adding MTK header to kernel.")
-	cat $(INSTALLED_KERNEL_TARGET) > $@
+	cat $(INSTALLED_KERNEL_TARGET).mtk.header $(INSTALLED_KERNEL_TARGET) \
+		> $@
 	
 INSTALLED_RAMDISK_TARGET := $(BUILT_RAMDISK_TARGET)
 $(INSTALLED_RAMDISK_TARGET): $(MKBOOTFS) $(INTERNAL_RAMDISK_FILES) | $(MINIGZIP)
@@ -51,7 +52,7 @@ $(PRODUCT_OUT)/recovery_kernel.mtk.header: $(recovery_kernel)
 		$(call make_header, $$((size)), "KERNEL", $@)
 $(PRODUCT_OUT)/recovery_kernel.mtk: $(PRODUCT_OUT)/recovery_kernel.mtk.header
 	$(call pretty,"Adding MTK header to recovery kernel.")
-	cat $(recovery_kernel) > $@
+	cat $(PRODUCT_OUT)/recovery_kernel.mtk.header $(recovery_kernel) > $@
 
 $(recovery_ramdisk).mtk.header: $(recovery_ramdisk)
 	size=$$($(call get-file-size,$(recovery_ramdisk))); \


### PR DESCRIPTION
Whatever you prebuild a kernel having MTK header or not, the MTK header will be missing for unknown reasons when rebuilding boot.img and recovery.img. Copying MTK header to kernel always to get it right.
