### PR TITLE
Used as vendor file to get audio config right

### DIFF
--- a/device_k1-turbo.mk
+++ b/device_k1-turbo.mk
@@ -30,7 +30,7 @@ PRODUCT_PACKAGES += \
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/configs/media_codecs.xml:system/etc/media_codecs.xml \
     $(LOCAL_PATH)/configs/media_profiles.xml:system/etc/media_profile.xml \
-    $(LOCAL_PATH)/audio/audio_policy.conf:system/etc/audio_policy.conf
+    $(LOCAL_PATH)/audio/audio_policy.conf:system/vendor/etc/audio_policy.conf
 
 # Wifi
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
In the latest R6 sources, PRODUCT_COPY_FILES for the audio_policy.conf does not wrok, 
and it just copys frameworks/av/services/audiopolicy/audio_policy.conf. Also, USE_CUSTOM_AUDIO_POLICY := 1 does not wrok.

audio_policy.conf define in tow paths(looking at frameworks/av/services/audiopolicy/AudioPolicyManager.cpp).
# define AUDIO_POLICY_CONFIG_FILE "/system/etc/audio_policy.conf"
# define AUDIO_POLICY_VENDOR_CONFIG_FILE "/vendor/etc/audio_policy.conf"

First, the system loads the vendor/etc directory. If it loads errors, then it will load the system/etc directory. If both of them are not loaded right, the system loads the default configuration file which called primary module.
